### PR TITLE
Change probe ports from 'http' to 'metrics'

### DIFF
--- a/charts/merge-bot/Chart.yaml
+++ b/charts/merge-bot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.12
+version: 1.6.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/merge-bot/values.yaml
+++ b/charts/merge-bot/values.yaml
@@ -111,14 +111,14 @@ resources:
 livenessProbe:
   httpGet:
     path: /healthy
-    port: http
+    port: metrics
   periodSeconds: 30
 
 # @ignored
 readinessProbe:
   httpGet:
     path: /healthy
-    port: http
+    port: metrics
 
 
 # @ignored


### PR DESCRIPTION
Updated liveness and readiness probes to use 'metrics' port instead of 'http'.